### PR TITLE
Fix for #4 https://github.com/smerrill/vagrant-gatling-rsync/issues/4 Disabling syncing to inactive machines

### DIFF
--- a/lib/vagrant-gatling-rsync/command/rsync_auto.rb
+++ b/lib/vagrant-gatling-rsync/command/rsync_auto.rb
@@ -122,9 +122,9 @@ module VagrantPlugins
           folders.each do |opts|
             ssh_info = opts[:machine].ssh_info
             if ssh_info
-	      VagrantPlugins::SyncedFolderRSync::RsyncHelper.rsync_single(opts[:machine], ssh_info, opts[:opts])
+              VagrantPlugins::SyncedFolderRSync::RsyncHelper.rsync_single(opts[:machine], ssh_info, opts[:opts])
             end
-	  end
+          end
         end
       end
     end


### PR DESCRIPTION
Whenever any synced folders are changed which are being synced with a machine which is not running the below undefined method happens. Noticeable when a synced folder is synced with more than one machine, one is running and the rest are not.

/Users/matthewking/.rvm/gems/ruby-2.0.0-p195/gems/vagrant-1.6.0.dev/plugins/synced_folders/rsync/helper.rb:57:in rsync_single': undefined method[]' for nil:NilClass (NoMethodError)
from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/command/rsync_auto.rb:123:in block (2 levels) in callback' from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/command/rsync_auto.rb:121:ineach'
from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/command/rsync_auto.rb:121:in block in callback' from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/command/rsync_auto.rb:120:ineach'
from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/command/rsync_auto.rb:120:in callback' from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/listen/listenosx.rb:47:incall'
from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/listen/listenosx.rb:47:in block in run' from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/listen/listenosx.rb:31:inloop'
from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/listen/listenosx.rb:31:in run' from /Users/matthewking/.vagrant.d/gems/gems/vagrant-gatling-rsync-0.0.2/lib/vagrant-gatling-rsync/command/rsync_auto.rb:77:inexecute'
from /Users/matthewking/.rvm/gems/ruby-2.0.0-p195/gems/vagrant-1.6.0.dev/lib/vagrant/cli.rb:42:in execute' from /Users/matthewking/.rvm/gems/ruby-2.0.0-p195/gems/vagrant-1.6.0.dev/lib/vagrant/environment.rb:248:incli'
from /Users/matthewking/.rvm/gems/ruby-2.0.0-p195/gems/vagrant-1.6.0.dev/bin/vagrant:166:in <top (required)>' from /Users/matthewking/.rvm/gems/ruby-2.0.0-p195/bin/vagrant:23:inload'
from /Users/matthewking/.rvm/gems/ruby-2.0.0-p195/bin/vagrant:23:in `'
