### PR TITLE
Support for Windows Hosts

### DIFF
--- a/lib/vagrant-gatling-rsync.rb
+++ b/lib/vagrant-gatling-rsync.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
     autoload :Errors, lib_path.join("errors")
     autoload :ListenOSX, lib_path.join("listen/listenosx")
     autoload :ListenLinux, lib_path.join("listen/listenlinux")
+    autoload :ListenWindows, lib_path.join("listen/listenwindows")
 
     # This returns the path to the source of this plugin.
     #

--- a/lib/vagrant-gatling-rsync/command/rsync_auto.rb
+++ b/lib/vagrant-gatling-rsync/command/rsync_auto.rb
@@ -94,9 +94,11 @@ module VagrantPlugins
           ListenOSX.new(paths, ignores, latency, @logger, self.method(:callback)).run
         when /linux/
           ListenLinux.new(paths, ignores, latency, @logger, self.method(:callback)).run
+        when /cygwin|mswin|mingw|bccwin|wince|emx/
+          ListenWindows.new(paths, ignores, latency, @logger, self.method(:callback)).run
         else
           # @TODO: Raise this earlier?
-          raise Errors::OnlyOSXLinuxSupportError
+          raise Errors::OSNotSupportedError
         end
 
         0

--- a/lib/vagrant-gatling-rsync/errors.rb
+++ b/lib/vagrant-gatling-rsync/errors.rb
@@ -7,8 +7,8 @@ module VagrantPlugins
         error_namespace("vagrant_gatling_rsync.errors")
       end
 
-      class OnlyOSXLinuxSupportError < VagrantGatlingRsyncError
-        error_key(:only_osx_linux_support)
+      class OSNotSupportedError < VagrantGatlingRsyncError
+        error_key(:os_not_supported)
       end
 
       class Vagrant15RequiredError < VagrantGatlingRsyncError

--- a/lib/vagrant-gatling-rsync/listen/listenwindows.rb
+++ b/lib/vagrant-gatling-rsync/listen/listenwindows.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
         monitor = WDM::Monitor.new
         changes = Queue.new
         @paths.keys.each do |path|
-          monitor.watch_recursively(path) { |change| changes << change }
+          monitor.watch_recursively(path.dup) { |change| changes << change }
         end
         Thread.new { monitor.run! }
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,8 +3,8 @@ en:
     gatling_ran: |-
       %{date}: The rsync operation completed in %{milliseconds} milliseconds.
     errors:
-      only_osx_linux_support: |-
-        The vagrant-gatling-rsync plugin currently only supports Max OS X and Linux hosts.
+      os_not_supported: |-
+        The vagrant-gatling-rsync plugin does not support your OS.
       vagrant_15_required: |-
         The vagrant-gatling-rsync plugin requires Vagrant 1.5.1 or newer to function.
 


### PR DESCRIPTION
ADD autoload the windows listener
ADD detect windows host and execute the proper listener
FIX frozen string error in windows listener
MOD error message for non supported OS