### PR TITLE
fix - compatibility with vagrant 2.2.5+

### DIFF
--- a/lib/vagrant-gatling-rsync/command/rsync_auto.rb
+++ b/lib/vagrant-gatling-rsync/command/rsync_auto.rb
@@ -67,7 +67,11 @@ module VagrantPlugins
 
             if folder_opts[:exclude]
               Array(folder_opts[:exclude]).each do |pattern|
-                ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(hostpath, pattern.to_s)
+               if Vagrant::VERSION < "2.2.5"
+                 ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(hostpath, pattern.to_s)
+               else
+                 ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(pattern.to_s)
+                end
               end
             end
           end


### PR DESCRIPTION
remove the hostpath in the call to exclude_to_regexp, as this was
changed in vagrant 2.2.5 [1] and now should only be passed the pattern

note that this change is written to be back/forwards compatible and
checks the version of Vagrant to do so

[1] https://github.com/hashicorp/vagrant/commit/1b0148bc783298c7aa16a519e133bb26bcc1cc9f