### PR TITLE
fix compatibility with vagrant 2.2.10

### DIFF
--- a/lib/vagrant-gatling-rsync/command/rsync_auto.rb
+++ b/lib/vagrant-gatling-rsync/command/rsync_auto.rb
@@ -67,10 +67,10 @@ module VagrantPlugins
 
             if folder_opts[:exclude]
               Array(folder_opts[:exclude]).each do |pattern|
-               if Vagrant::VERSION < "2.2.5"
-                 ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(hostpath, pattern.to_s)
-               else
-                 ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(pattern.to_s)
+                if Gem::Version.new(Vagrant::VERSION) < Gem::Version.new('2.2.5')
+                  ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(hostpath, pattern.to_s)
+                else
+                  ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(pattern.to_s)
                 end
               end
             end


### PR DESCRIPTION
w/r/t 2c2bd95f190467a274db67acec016073c4b750c6 in which i added a
VERSION check but did it the lazy way - instead use Gem::Version, which
is part of the stdlib, to do the version comparison so checking against
2.2.10 will pass and still maintain backwards compat for those using
lower than 2.2.5

fix the alignment here, indentation of this if/else/end block was a
little off