### PR TITLE
Use Gem::Version.new method to wrap string version before compare

### DIFF
--- a/lib/vagrant-gatling-rsync/command/rsync_auto.rb
+++ b/lib/vagrant-gatling-rsync/command/rsync_auto.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
     class GatlingRsyncAuto < Vagrant.plugin(2, :command)
       # This is a sanity check to make sure no one is attempting to install
       # this into an early Vagrant version.
-      if Vagrant::VERSION < "1.5.1"
+      if Gem::Version.new(Vagrant::VERSION) < Gem::Version.new("1.5.1")
         raise Errors::Vagrant15RequiredError
       end
 
@@ -67,7 +67,7 @@ module VagrantPlugins
 
             if folder_opts[:exclude]
               Array(folder_opts[:exclude]).each do |pattern|
-               if Vagrant::VERSION < "2.2.5"
+               if Gem::Version.new(Vagrant::VERSION) < Gem::Version.new("2.2.5")
                  ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(hostpath, pattern.to_s)
                else
                  ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(pattern.to_s)


### PR DESCRIPTION
Otherwise we'll end up with incorrect result.
Version in string format cannot be reliably compared against one
another.

It seems we must use Gem::Version class to make sure we're correctly
comparing versions.

Example:

```
irb* puts "2.2.10" > "2.2.5",
irb* "2.2.10" < "2.2.5",
irb* Gem::Version.new("2.2.10") > Gem::Version.new("2.2.5"),
irb> Gem::Version.new("2.2.10") < Gem::Version.new("2.2.5")
false
true
true
false
=> nil
```

Expected result "2.2.10" version is greater then "2.2.5".
Comparing strings directly results in incorrect compare.

However comparing the same versions wrapped with Gem::Version.new() will
result in expected result.

Above string version compare worked until 2 digit patch version.
With 2 digit patch version lexical compare is first looking into "1" and
it's indeed lower then "5" and "0" is just skipped.