### PR TITLE
Test Vagrant version using Gem::Version for accuracy

### DIFF
--- a/lib/vagrant-gatling-rsync/command/rsync_auto.rb
+++ b/lib/vagrant-gatling-rsync/command/rsync_auto.rb
@@ -67,7 +67,7 @@ module VagrantPlugins
 
             if folder_opts[:exclude]
               Array(folder_opts[:exclude]).each do |pattern|
-               if Vagrant::VERSION < "2.2.5"
+               if Gem::Version.new(Vagrant::VERSION) < Gem::Version.new("2.2.5")
                  ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(hostpath, pattern.to_s)
                else
                  ignores << VagrantPlugins::SyncedFolderRSync::RsyncHelper.exclude_to_regexp(pattern.to_s)

--- a/lib/vagrant-gatling-rsync/version.rb
+++ b/lib/vagrant-gatling-rsync/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module GatlingRsync
-    VERSION = "1.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
The current API version check fails now that Vagrant has a patch version in the double digits, i.e. string comparison sees `2.2.10` as less than `2.2.5` which is not the behavior we want.

The solutions is to wrap each semver string in a `Gem::Version` object before comparison.